### PR TITLE
BB_REPO default missing colon

### DIFF
--- a/bin/steps/buildbot-install
+++ b/bin/steps/buildbot-install
@@ -11,7 +11,7 @@ if [ ! "$BB_CHECKOUT" ]; then
 fi
 
 if [ ! "$BB_REPO" ]; then
-    BB_REPO='https//github.com/buildbot/buildbot'
+    BB_REPO='https://github.com/buildbot/buildbot'
 fi
 
 if [ ! "$BB_WWW_PLUGINS" ]; then


### PR DESCRIPTION
I found this typo today. The BB_REPO is currently:

BB_REPO='https//github.com/buildbot/buildbot'

When it should be:

BB_REPO='https://github.com/buildbot/buildbot'
