### PR TITLE
target ‘/build/app/.profile.d/python.webconcurrency.sh’ is not a directory

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -168,7 +168,7 @@ set-default-env PYTHONHASHSEED random
 set-default-env PYTHONPATH /app/
 
 # Install sane-default script for WEB_CONCURRENCY environment variable.
-cp $ROOT_DIR/vendor/python.webconcurrency.sh $WEBCONCURRENCY_PROFILE_PATH
+cp "$ROOT_DIR/vendor/python.webconcurrency.sh" "$WEBCONCURRENCY_PROFILE_PATH"
 
 
 # Experimental post_compile hook.


### PR DESCRIPTION
I get the following error when trying to push this to heroku:

remote:        Successfully installed buildbot-www
remote:        Cleaning up...
remote: mkdir /app/master
remote: creating /app/master/master.cfg.sample
remote: populating public_html/
remote: creating database (sqlite:///state.sqlite)
remote: buildmaster configured in /app/master
remote: -----> Copying config file
remote: cp: target ‘/build/app/.profile.d/python.webconcurrency.sh’ is not a directory
remote: There was a problem deploying your code: Command returned a non-zero exit status

I think the call is happening on line 202 here: [python buildpack compile](https://github.com/heroku/heroku-buildpack-python/blob/master/bin/compile)

Any ideas?

Thanks
